### PR TITLE
トップページからどの風をよむかのページに遷移するボタンの実装

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -13,6 +13,6 @@
 
   <!-- ボタン表示 -->
   <div class="absolute bottom-16 w-full flex justify-center">
-    <button class="text-2xl bg-green-600 p-3 text-white">風を読む</button>
+    <%= link_to '風を読む', select_search_datas_path, class: "text-2xl bg-green-600 p-3 text-white" %>
   </div>
 </div>


### PR DESCRIPTION
どちらの風を読むかの(select)ページへの遷移する用のボタンの実装。

ログイン後のヘッダーにも同様のlink_toの実装が必要。