### PR TITLE
風情報取得ページのレイアウトの修正

### DIFF
--- a/app/views/search_datas/new.html.erb
+++ b/app/views/search_datas/new.html.erb
@@ -4,28 +4,25 @@
     <div class="text-3xl"><%= @location_name %>競馬場</div>
   </div>
 
-  <!-- 競馬場コース画像と方位マークの挿入 -->
-  <div class="absolute w-full flex justify-center mx-auto mt-40">
-    <div class="relative mx-auto w-full max-w-xl">
-      <%= image_tag @course_image, alt: "#{@location_name}競馬場コース", class: "max-w-xl h-auto" %>
-
-      <!-- 方位マークの表示 -->
-      <div class="absolute top-5 right-5">
-        <%= image_tag 'direction.png', alt: "N", style: "transform: rotate(#{@course_rotation}); width: 50px;" %>
-      </div>
-    </div>
-  </div>
-
-  <!-- ボタン表示部分 -->
-  <div class="absolute bottom-10 w-full flex justify-center mx-auto">
+  <!-- 風の情報を取得するボタン -->
+  <div class="absolute top-28 w-full flex justify-center mx-auto">
     <div>
       <button id="fetch-wind" class="text-2xl bg-green-600 p-3 text-white w-full text-center">風の情報を取得する</button>
       <div id="wind-result" class="mt-4 text-2xl text-blue-500 w-full text-center"></div>
     </div>
   </div>
+
+  <!-- 芝/砂と距離選択の表示 -->
+  <%= render 'shared/course_select' %>
+
+  <!-- 競馬場コース画像と方位マークの挿入 -->
+  <div class="absolute w-full flex justify-center mx-auto mt-80"> <!-- コース画像の位置をさらに下に -->
+    <%= render 'shared/course_information' %>
+  </div>
 </div>
 
 <script>
+  // 風の情報を取得するボタンのイベントリスナー
   document.getElementById('fetch-wind').addEventListener('click', function() {
     const location = "<%= params[:location] %>"; // 検索結果から場所を取得
 
@@ -48,6 +45,27 @@
     .catch(error => {
       console.error('Error fetching wind data:', error);
       document.getElementById('wind-result').textContent = '風の情報を取得できませんでした。';
+    });
+  });
+
+  // ドロップダウンメニューの挙動を制御するコード
+  document.querySelectorAll('[data-dropdown-target="button"]').forEach(button => {
+    button.addEventListener('click', function() {
+      const dropdown = this.nextElementSibling;  // 次の兄弟要素（ドロップダウンメニュー）
+      dropdown.classList.toggle('hidden');  // メニューの表示/非表示を切り替え
+    });
+  });
+
+  // ドロップダウン内の選択肢をクリックした時の処理
+  document.querySelectorAll('[data-action="click->dropdown#selectOption"]').forEach(option => {
+    option.addEventListener('click', function() {
+      const selectedValue = this.getAttribute('data-value');
+      const button = this.closest('[data-dropdown-target="dropdown"]').previousElementSibling;  // 親メニューのボタン
+
+      // ボタンの中のspanを更新
+      button.querySelector('span').textContent = this.textContent.trim();
+
+      this.closest('[data-dropdown-target="dropdown"]').classList.add('hidden');  // ドロップダウンを隠す
     });
   });
 </script>

--- a/app/views/shared/_course_information.html.erb
+++ b/app/views/shared/_course_information.html.erb
@@ -1,0 +1,8 @@
+<div class="relative mx-auto w-full max-w-xl">
+  <%= image_tag @course_image, alt: "#{@location_name}競馬場コース", class: "max-w-xl h-auto" %>
+
+  <!-- 方位マークの表示 -->
+  <div class="absolute top-5 right-5">
+    <%= image_tag 'direction.png', alt: "N", style: "transform: rotate(#{@course_rotation}); width: 50px;" %>
+  </div>
+</div>

--- a/app/views/shared/_course_select.html.erb
+++ b/app/views/shared/_course_select.html.erb
@@ -1,0 +1,34 @@
+<!-- 芝/砂と距離の選択を横並びで表示 -->
+<div class="absolute top-56 w-full flex justify-center mx-auto space-x-8">
+  <!-- 芝/砂の選択 -->
+  <div class="relative z-50">
+    <button data-dropdown-target="button" type="button" class="inline-flex justify-center w-64 rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none" id="options-menu" aria-haspopup="true" aria-expanded="true">
+      <span>芝か砂か選択してください</span>
+      <svg class="-mr-1 ml-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+      </svg>
+    </button>
+    <div data-dropdown-target="dropdown" class="origin-top-right absolute left-0 mt-2 w-64 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 hidden" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
+      <div class="py-1" role="none">
+        <div class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 cursor-pointer" data-value="turf" data-action="click->dropdown#selectOption">芝</div>
+        <div class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 cursor-pointer" data-value="dirt" data-action="click->dropdown#selectOption">砂</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 距離の選択 -->
+  <div class="relative z-50">
+    <button data-dropdown-target="button" type="button" class="inline-flex justify-center w-64 rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none" id="distance-menu" aria-haspopup="true" aria-expanded="true">
+      <span>距離を選択してください</span>
+      <svg class="-mr-1 ml-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+      </svg>
+    </button>
+    <div data-dropdown-target="dropdown" class="origin-top-right absolute left-0 mt-2 w-64 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 hidden" role="menu" aria-orientation="vertical" aria-labelledby="distance-menu">
+      <div class="py-1" role="none">
+        <div class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 cursor-pointer" data-value="1600" data-action="click->dropdown#selectOption">1600m</div>
+        <div class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 cursor-pointer" data-value="2000" data-action="click->dropdown#selectOption">2000m</div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
風情報取得のボタンを上にもってきて、
取得した風のデータを後々そのまま下のコースレイアウト画像に風の方向のviewのせるときの
paramsとして使えるようにする。