### PR TITLE
各種アクセス制限の整理

### DIFF
--- a/app/controllers/search_datas_controller.rb
+++ b/app/controllers/search_datas_controller.rb
@@ -1,7 +1,7 @@
 class SearchDatasController < ApplicationController
   include CoursesHelper
 
-  before_action :authenticate_user!, only: [ :create, :destroy, :edit ]
+  before_action :authenticate_user!, except: [:new, :select]
 
   def select
     @error_message = params[:error]
@@ -29,7 +29,7 @@ class SearchDatasController < ApplicationController
   end
 
   def index
-    @q = SearchData.ransack(params[:q])
+    @q = current_user.search_datas.ransack(params[:q])
     @search_datas = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(8)
   end
 

--- a/app/controllers/search_datas_controller.rb
+++ b/app/controllers/search_datas_controller.rb
@@ -1,7 +1,7 @@
 class SearchDatasController < ApplicationController
   include CoursesHelper
 
-  before_action :authenticate_user!, except: [:new, :select]
+  before_action :authenticate_user!, except: [ :new, :select ]
 
   def select
     @error_message = params[:error]


### PR DESCRIPTION
各種アクセス制限の整理
主に人のマイページに入れてしまっていたことを修正。
その人に紐づいた風の情報のみマイページで表示されるように修正。